### PR TITLE
Fix HP display/calc in Creation and Sheet

### DIFF
--- a/AEtherSlay/frmCharacterCreation.cs
+++ b/AEtherSlay/frmCharacterCreation.cs
@@ -645,7 +645,7 @@ namespace AEtherSlay
                 txtAC.Text = ac.ToString();
                 lblAlignment.Text = alignment;
                 txtInit.Text = txtDexMod.Text;
-                txtHP.Text = (hitDiceSides + ((statRolls[2] - 10) / 2)).ToString();
+                txtHP.Text = (hitDiceSides + statMods[1]).ToString();
 
                 bindWeaponComboBox(cbWeapon1, primaryWeaponChoices);
                 bindWeaponComboBox(cbWeapon2, secondaryWeaponChoices);

--- a/AEtherSlay/frmCharacterSheets.cs
+++ b/AEtherSlay/frmCharacterSheets.cs
@@ -88,7 +88,7 @@ namespace AEtherSlay
             txtAC.Text = selectedCharacter.ac.ToString();
             lblAlignment.Text = selectedCharacter.alignment;
             txtInit.Text = txtDexMod.Text;
-            txtHP.Text = (selectedCharacter.hitDiceSides + ((selectedCharacter.stats[2] - 10) / 2)).ToString();
+            txtHP.Text = (selectedCharacter.hitDiceSides + selectedCharacter.statMods[1]).ToString();
             if(selectedCharacter.armor != null)
             {
                 storedArmor = selectedCharacter.armor;


### PR DESCRIPTION
frmCharacterCreation and frmCharacterSheets both use `statRolls[2] - 10) / 2` to calculate the modifier for HP

statRolls[2] is the index for Dexterity as listed ln 230 in frmCharCreation.cs

statMods[1] is the correct attribute and is already precalculated rather than calculating the modifier on the fly 